### PR TITLE
Allow TYPE_USE on MagicConstant, Pattern, RegExp and Subst

### DIFF
--- a/common/src/main/java/org/intellij/lang/annotations/Language.java
+++ b/common/src/main/java/org/intellij/lang/annotations/Language.java
@@ -44,7 +44,7 @@ import static java.lang.annotation.ElementType.*;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ METHOD, FIELD, PARAMETER, LOCAL_VARIABLE, ANNOTATION_TYPE })
+@Target({ METHOD, FIELD, PARAMETER, LOCAL_VARIABLE, TYPE_USE, ANNOTATION_TYPE })
 public @interface Language {
   /**
    * Language name like "JAVA", "HTML", "XML", "RegExp", etc.

--- a/common/src/main/java/org/intellij/lang/annotations/MagicConstant.java
+++ b/common/src/main/java/org/intellij/lang/annotations/MagicConstant.java
@@ -80,6 +80,7 @@ import java.lang.annotation.*;
 @Target({
           ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE,
           ElementType.ANNOTATION_TYPE,
+          ElementType.TYPE_USE,
           ElementType.METHOD
         })
 public @interface MagicConstant {

--- a/common/src/main/java/org/intellij/lang/annotations/Pattern.java
+++ b/common/src/main/java/org/intellij/lang/annotations/Pattern.java
@@ -45,7 +45,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ METHOD, FIELD, PARAMETER, LOCAL_VARIABLE, ANNOTATION_TYPE })
+@Target({ METHOD, FIELD, PARAMETER, LOCAL_VARIABLE, TYPE_USE, ANNOTATION_TYPE })
 public @interface Pattern {
     /**
      * A regular expression that matches all the valid string literals that assigned to the annotated variables,

--- a/common/src/main/java/org/intellij/lang/annotations/RegExp.java
+++ b/common/src/main/java/org/intellij/lang/annotations/RegExp.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({METHOD, FIELD, PARAMETER, LOCAL_VARIABLE, ANNOTATION_TYPE})
+@Target({METHOD, FIELD, PARAMETER, LOCAL_VARIABLE, TYPE_USE, ANNOTATION_TYPE})
 @Language("RegExp")
 public @interface RegExp {
     /**

--- a/common/src/main/java/org/intellij/lang/annotations/Subst.java
+++ b/common/src/main/java/org/intellij/lang/annotations/Subst.java
@@ -41,7 +41,7 @@ import java.lang.annotation.*;
  * @see Pattern
  */
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.LOCAL_VARIABLE, ElementType.PARAMETER})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE, ElementType.PARAMETER})
 public @interface Subst {
     String value();
 }

--- a/java5/build.gradle
+++ b/java5/build.gradle
@@ -36,7 +36,12 @@ sourceSets {
 task generateSrc(type: Copy) {
     from project(':common').sourceSets.main.java
     into generatedSourcesDir
-    filter { line -> line.replaceAll(", ElementType.TYPE_USE", "")}
+    // This filter removes
+    // 1. @Target({LOCAL_VARIABLE, TYPE_USE, ANNOTATION_TYPE}) => @Target({LOCAL_VARIABLE,  ANNOTATION_TYPE})
+    // 2. @Target({ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE, ElementType.PARAMETER}) => @Target({ElementType.LOCAL_VARIABLE,  ElementType.PARAMETER})
+    // 3. @Target({ElementType.FIELD, ElementType.TYPE_USE}) => @Target({ElementType.FIELD, })
+    // 4. @Target({ElementType.TYPE_USE, ElementType.FIELD}) => @Target({ ElementType.FIELD})
+    filter { line -> line.replaceAll("\\b(ElementType.)?TYPE_USE\\b(\\w*,)?", "") }
 }
 
 compileJava {


### PR DESCRIPTION
This should fix #43 (and supersedes #77).

The main goal of this PR is to enable documenting the code on the generic type parameters. Later this could also be integrated in IDE inspection.

After this PR and this is released a developer can document it's API this way :

```java
Map<@Pattern("[a-z]+(-[a-z]+)*") String, @Language("RegExp") String> regexes
```

----

Since `TYPE_USE` is not available prior Java 8, the Java 5 project stripped this enum value from source. However it was missing some cases. This PR is more lenient in detecting and stripping this value.

1. `@Target({LOCAL_VARIABLE, TYPE_USE, ANNOTATION_TYPE})` => `@Target({LOCAL_VARIABLE,  ANNOTATION_TYPE})`
2. `@Target({ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE, ElementType.PARAMETER})` => `@Target({ElementType.LOCAL_VARIABLE,  ElementType.PARAMETER})`
3. `@Target({ElementType.FIELD, ElementType.TYPE_USE})` => `@Target({ElementType.FIELD, })`
4. `@Target({ElementType.TYPE_USE, ElementType.FIELD})` => `@Target({ ElementType.FIELD})`